### PR TITLE
regexp bug fix

### DIFF
--- a/lib/App/envfile.pm
+++ b/lib/App/envfile.pm
@@ -53,7 +53,7 @@ sub parse_envfile {
 sub _try_any_config_file {
     my ($self, $file) = @_;
 
-    my ($ext) = $file =~ /\.(\w+)/;
+    my ($ext) = $file =~ /\.(\w+)$/;
     if (my $type = $EXTENTIONS_MAP->{lc($ext || '')}) {
         my $env;
         if ($type eq 'Perl') {


### PR DESCRIPTION
俺のホームディレクトリが `urabe.shohei` の為すべてのファイルの拡張子が `.shohei`と判定されるというかっこいいものの困るバグの修正です
