### PR TITLE
Parse quoted value

### DIFF
--- a/lib/App/envfile.pm
+++ b/lib/App/envfile.pm
@@ -84,6 +84,7 @@ sub _slurp {
 sub _parse_line {
     my ($self, $line) = @_;
     my ($key, $value) = map { my $str = $_; $str =~ s/^\s+|\s+$//g; $str } split '=', $line, 2;
+    $value =~ s/^['"](.*)['"]$/$1/;
     return $key, $value;
 }
 

--- a/t/02_parse_envfile.t
+++ b/t/02_parse_envfile.t
@@ -102,6 +102,22 @@ test_parse_envfile(
 FOO="bar"
 ENV
 
+test_parse_envfile(
+    expects => { 'FOO' => "'bar", 'BAR' => "foo'" },
+    desc    => 'single quoted value, no pair',
+    input   => << 'ENV');
+FOO='bar
+BAR=foo'
+ENV
+
+test_parse_envfile(
+    expects => { 'FOO' => '"bar', 'BAR' => 'foo"' },
+    desc    => 'double quoted value, no pair',
+    input   => << 'ENV');
+FOO="bar
+BAR=foo"
+ENV
+
 runtest 'file not found' => sub {
     eval { App::envfile->new->parse_envfile('foo.bar') };
     ok $@, 'throw error';

--- a/t/02_parse_envfile.t
+++ b/t/02_parse_envfile.t
@@ -88,6 +88,20 @@ FOO = bar
 
 ENV
 
+test_parse_envfile(
+    expects => { 'FOO' => 'bar' },
+    desc    => 'single quoted value',
+    input   => << 'ENV');
+FOO='bar'
+ENV
+
+test_parse_envfile(
+    expects => { 'FOO' => 'bar' },
+    desc    => 'double quoted value',
+    input   => << 'ENV');
+FOO="bar"
+ENV
+
 runtest 'file not found' => sub {
     eval { App::envfile->new->parse_envfile('foo.bar') };
     ok $@, 'throw error';


### PR DESCRIPTION
Hi,

I think stripping quotes at the head and the last of values is useful. Ruby's library [dotenv](https://github.com/bkeepers/dotenv) (used by [foreman](https://github.com/ddollar/foreman)) works like this.

https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/environment.rb#L11
